### PR TITLE
Projects Create Flow

### DIFF
--- a/web/app/api/projects/route.ts
+++ b/web/app/api/projects/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server"
+import { prisma } from "@/lib/prisma"
+
+export async function GET(req: NextRequest) {
+  const projects = await prisma.project.findMany({ orderBy: { createdAt: "desc" } })
+  return NextResponse.json({ projects })
+}
+
+export async function POST(req: NextRequest) {
+  const { name } = await req.json()
+  if (!name) return NextResponse.json({ error: "name required" }, { status: 400 })
+  const project = await prisma.project.create({ data: { name, status: "drafting" } as any })
+  return NextResponse.json({ project })
+}

--- a/web/app/project/[id]/setup/page.tsx
+++ b/web/app/project/[id]/setup/page.tsx
@@ -1,0 +1,23 @@
+import PageShell from "../../../../components/layout/PageShell"
+import Link from "next/link"
+
+export default function SetupPage({ params }: { params: { id: string } }) {
+  const { id } = params
+  return (
+    <PageShell>
+      <div className="mx-auto max-w-4xl">
+        <h1 className="text-xl font-semibold mb-4">Start your application</h1>
+        <div className="grid md:grid-cols-2 gap-6">
+          <Link href={`/project/${id}/draft`} className="rounded-lg border bg-white shadow-card p-6 hover:bg-gray-50">
+            <div className="text-lg font-semibold mb-2">Blank document</div>
+            <p className="text-sm text-gray-600">Paste the application text from a web portal and start writing.</p>
+          </Link>
+          <Link href={`/project/${id}/materials`} className="rounded-lg border bg-white shadow-card p-6 hover:bg-gray-50">
+            <div className="text-lg font-semibold mb-2">Start from an existing document</div>
+            <p className="text-sm text-gray-600">Upload a .docx application to edit directly.</p>
+          </Link>
+        </div>
+      </div>
+    </PageShell>
+  )
+}

--- a/web/app/projects/page.tsx
+++ b/web/app/projects/page.tsx
@@ -1,17 +1,52 @@
 import PageShell from "../../components/layout/PageShell"
-import GrantsTable from "../../components/grants/GrantsTable"
+import NewGrantDialog from "../../components/projects/NewGrantDialog"
 
-export default function ProjectsPage() {
+async function getProjects() {
+  const base = (process.env.NEXT_PUBLIC_BASE_URL || "").replace(/\/$/, "")
+  const url = base ? `${base}/api/projects` : "/api/projects"
+  const res = await fetch(url, {
+    cache: "no-store",
+    next: { revalidate: 0 },
+  })
+  if (!res.ok) {
+    console.error("Failed to load projects", res.statusText)
+    return []
+  }
+  const json = await res.json()
+  return (json.projects as any[]) || []
+}
+
+export default async function ProjectsPage() {
+  const projects = await getProjects()
   return (
     <PageShell>
       <div className="mx-auto max-w-screen-2xl">
         <div className="flex items-center justify-between mb-4">
           <h1 className="text-xl font-semibold">Grants</h1>
-          <button className="rounded-md bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] text-sm px-3 py-2 hover:opacity-90">
-            + New Grant
-          </button>
+          <NewGrantDialog />
         </div>
-        <GrantsTable />
+
+        <div className="rounded-lg border bg-white overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 text-gray-600">
+              <tr>
+                <th className="text-left font-medium px-4 py-3">Name</th>
+                <th className="text-left font-medium px-4 py-3">Status</th>
+                <th className="text-left font-medium px-4 py-3">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {projects?.map((p: any) => (
+                <tr key={p.id} className="border-t hover:bg-gray-50">
+                  <td className="px-4 py-3"><a className="underline" href={`/project/${p.id}/draft`}>{p.name}</a></td>
+                  <td className="px-4 py-3">{p.status || "—"}</td>
+                  <td className="px-4 py-3 text-gray-500">{new Date(p.createdAt).toLocaleString()}</td>
+                </tr>
+              ))}
+              {!projects?.length && <tr><td className="px-4 py-6 text-gray-500" colSpan={3}>No grants yet</td></tr>}
+            </tbody>
+          </table>
+        </div>
       </div>
     </PageShell>
   )

--- a/web/components/projects/NewGrantDialog.tsx
+++ b/web/components/projects/NewGrantDialog.tsx
@@ -1,0 +1,46 @@
+"use client"
+import * as Dialog from "@radix-ui/react-dialog"
+import React from "react"
+import { useRouter } from "next/navigation"
+
+export default function NewGrantDialog() {
+  const router = useRouter()
+  const [open, setOpen] = React.useState(false)
+  const [name, setName] = React.useState("")
+  const [loading, setLoading] = React.useState(false)
+
+  async function create() {
+    setLoading(true)
+    const res = await fetch("/api/projects", { method: "POST", body: JSON.stringify({ name }), headers: { "Content-Type":"application/json" } })
+    const json = await res.json()
+    setLoading(false)
+    if (json?.project?.id) {
+      setOpen(false)
+      setName("")
+      router.push(`/project/${json.project.id}/setup`)
+      router.refresh()
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Trigger asChild>
+        <button className="rounded-md bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] text-sm px-3 py-2 hover:opacity-90">+ New Grant</button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/30" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg border w-[90vw] max-w-md p-6 shadow-card">
+          <Dialog.Title className="text-lg font-semibold mb-2">Create a new grant</Dialog.Title>
+          <div className="space-y-2">
+            <label className="text-sm">Name</label>
+            <input value={name} onChange={e=>setName(e.target.value)} className="w-full rounded-md border px-3 py-2" placeholder="e.g., NSF SBIR Phase I" />
+          </div>
+          <div className="flex justify-end gap-2 mt-4">
+            <Dialog.Close className="rounded-md border px-3 py-2 text-sm">Cancel</Dialog.Close>
+            <button onClick={create} disabled={!name || loading} className="rounded-md bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] px-3 py-2 text-sm disabled:opacity-60">{loading ? "Creating..." : "Create"}</button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/web/prisma/schema.prisma
+++ b/web/prisma/schema.prisma
@@ -255,6 +255,7 @@ model Section {
 }
 
 model Upload {
+  createdAt  DateTime @default(now())
   id         String   @id @default(cuid())
   projectId  String
   kind       String


### PR DESCRIPTION
# PR: Projects API + New Grant flow

**What**
- `POST/GET /api/projects` to create/list projects
- `/projects` page wired to the API
- **New Grant** dialog → after create, redirect to `/project/:id/setup`
- `/project/:id/setup` lets users choose **Blank** or **Start from document (.docx)**

**Why**
- Matches the first step of Grantable: create a grant from Grants > New

**Test**
- Go to `/projects` → click **+ New Grant** → create → see setup page → navigate to Draft or Materials
